### PR TITLE
fix: make nodemon work without `dist` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "homepage": "https://github.com/stanislav-halyn/adventure-capitalist-game#readme",
   "scripts": {
-    "start:prod": "npm run build-ts && node ./dist/index.js",
-    "start:dev": "npm run watch-node",
+    "start:prod": "npm run build-ts && NODE_ENV=production node ./dist/index.js",
+    "start:dev": "NODE_ENV=development npm run watch-node",
     "build-ts": "tsc",
     "watch-ts": "tsc --watch",
     "watch-node": "nodemon ./src/index.ts",

--- a/src/config/aliases.ts
+++ b/src/config/aliases.ts
@@ -1,7 +1,12 @@
 import moduleAlias from 'module-alias';
 import path from 'path';
 
-const rootPath = path.resolve(__dirname, '..', '..', 'dist');
+
+const rootFolder = process.env.NODE_ENV === 'development'
+  ? 'src'
+  : 'dist';
+
+const rootPath = path.resolve(__dirname, '..', '..', rootFolder);
 moduleAlias.addAliases({
   '@src': rootPath,
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,3 +1,3 @@
-import { startServer } from './server';
+import { startServer } from '@src/server';
 
 startServer(3000);


### PR DESCRIPTION
This PR includes a fix to the nodemon to make it work without `dist` folder.